### PR TITLE
WQP625 reorder column mappings to allow longer mappings to go before shorter

### DIFF
--- a/src/main/java/gov/usgs/cida/wqp/webservice/StationColumnMapper.java
+++ b/src/main/java/gov/usgs/cida/wqp/webservice/StationColumnMapper.java
@@ -14,19 +14,18 @@ public class StationColumnMapper extends TransformOutputStream {
 	static {
 		patterns = new ManyPatternTransformer();
 		
-//		DATA_SOURCE,
-		patterns.addMapping("ORGANIZATION","OrganizationIdentifier");
 		patterns.addMapping("ORGANIZATION_NAME","OrganizationFormalName");
+		patterns.addMapping("ORGANIZATION","OrganizationIdentifier");
 		patterns.addMapping("SITE_ID","MonitoringLocationIdentifier");
 		patterns.addMapping("STATION_NAME","MonitoringLocationName");
 		patterns.addMapping("STATION_TYPE_NAME","MonitoringLocationTypeName");
 		patterns.addMapping("DESCRIPTION_TEXT","MonitoringLocationDescriptionText");
 		patterns.addMapping("HUC_8", "HUCEightDigitCode");
 		patterns.addMapping("HUC_12", "HUCTwelveDigitCode");
-		patterns.addMapping("DRAIN_AREA_VALUE","DrainageAreaMeasure/MeasureValue");
-		patterns.addMapping("DRAIN_AREA_UNIT","DrainageAreaMeasure/MeasureUnitCode");
 		patterns.addMapping("CONTRIB_DRAIN_AREA_VALUE","ContributingDrainageAreaMeasure/MeasureValue");
 		patterns.addMapping("CONTRIB_DRAIN_AREA_UNIT","ContributingDrainageAreaMeasure/MeasureUnitCode");
+		patterns.addMapping("DRAIN_AREA_VALUE","DrainageAreaMeasure/MeasureValue");
+		patterns.addMapping("DRAIN_AREA_UNIT","DrainageAreaMeasure/MeasureUnitCode");
 		patterns.addMapping("LATITUDE","LatitudeMeasure");
 		patterns.addMapping("LONGITUDE","LongitudeMeasure");
 		patterns.addMapping("MAP_SCALE","SourceMapScaleNumeric");
@@ -54,6 +53,7 @@ public class StationColumnMapper extends TransformOutputStream {
 //		STATION_ID,
 //		SITE_TYPE,
 //		GOVERNMENTAL_UNIT_CODE	
+//		DATA_SOURCE,
 		
 		transform = new TerminatingTransformer("\n".getBytes(), patterns);
 	}

--- a/src/main/resources/mybatis/dataMapper.xml
+++ b/src/main/resources/mybatis/dataMapper.xml
@@ -346,7 +346,6 @@
 			STATION_TYPE_NAME,
 			DESCRIPTION_TEXT,
 			HUC_8 ,
-			HUC_12 ,
 			DRAIN_AREA_VALUE,
 			DRAIN_AREA_UNIT,
 			CONTRIB_DRAIN_AREA_VALUE,
@@ -375,9 +374,6 @@
 			WELL_DEPTH_UNIT,
 			HOLE_DEPTH_VALUE,
 			HOLE_DEPTH_UNIT,
-			STATION_ID, 
-			SITE_TYPE, 
-			GOVERNMENTAL_UNIT_CODE,
 			DATA_SOURCE			
         <include refid="dataMapper.stationsBase"/>
             order by organization,


### PR DESCRIPTION
 substring mappings: for example: organization_name before organization