### PR TITLE
DifferedResult implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,6 +302,7 @@
             <version>11.2.0.2.0-1</version>
             <scope>provided</scope>
         </dependency>
+        
 		<!-- ================================================================== -->
 		<!-- Testing dependencies -->
 		<!-- ================================================================== -->
@@ -335,6 +336,17 @@
 			<version>0.2</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+        <dependency>
+            <groupId>com.github.springtestdbunit</groupId>
+            <artifactId>spring-test-dbunit</artifactId>
+            <version>1.2.1</version>
+            <scope>test</scope>
+        </dependency>		
 		<!-- ================================================================== -->
 		<!-- Logging dependencies -->
 		<!-- ================================================================== -->
@@ -400,6 +412,7 @@
 		   	<artifactId>poi-ooxml</artifactId>
 		   	<version>3.11</version>
 		</dependency>
+		
 		<!-- ================================================================== -->
 		<!-- Spring 4 dependencies -->
 		<!-- http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#overview-core-container -->
@@ -484,17 +497,6 @@
 <!-- 	      <version>2.1.9.RELEASE</version> -->
 <!-- 		  <scope>package</scope> -->
 <!-- 	    </dependency> -->
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-        <dependency>
-            <groupId>com.github.springtestdbunit</groupId>
-            <artifactId>spring-test-dbunit</artifactId>
-            <version>1.2.1</version>
-            <scope>test</scope>
-        </dependency>
 
    		
 		<!-- ================================================================== -->

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,6 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<cida.maven.url>http://internal.cida.usgs.gov/maven</cida.maven.url>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<spring.version>4.1.5.RELEASE</spring.version>
 		<warName>wqp</warName>
 		<mybatis-version>3.2.8</mybatis-version>
@@ -427,6 +426,10 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-web</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/src/main/java/gov/usgs/cida/wqp/webservice/SimpleStation/SimpleStationController.java
+++ b/src/main/java/gov/usgs/cida/wqp/webservice/SimpleStation/SimpleStationController.java
@@ -1,10 +1,9 @@
 package gov.usgs.cida.wqp.webservice.SimpleStation;
 
-import java.math.BigDecimal;
-
 import gov.cida.cdat.control.Control;
 import gov.cida.cdat.control.SCManager;
 import gov.cida.cdat.control.Time;
+import gov.cida.cdat.io.Closer;
 import gov.usgs.cida.wqp.dao.ICountDao;
 import gov.usgs.cida.wqp.dao.IDao;
 import gov.usgs.cida.wqp.dao.IStreamingDao;
@@ -19,6 +18,9 @@ import gov.usgs.cida.wqp.util.MybatisConstants;
 import gov.usgs.cida.wqp.validation.ParameterValidation;
 import gov.usgs.cida.wqp.validation.ValidationConstants;
 import gov.usgs.cida.wqp.webservice.HeaderWorker;
+import gov.usgs.cida.wqp.webservice.StationController;
+
+import java.math.BigDecimal;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -27,10 +29,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.context.request.async.DeferredResult;
 
 @Controller
 public class SimpleStationController implements HttpConstants, MybatisConstants, ValidationConstants {
@@ -62,20 +64,20 @@ public class SimpleStationController implements HttpConstants, MybatisConstants,
 	 * SimpleStation HEAD request
 	 */
 	@RequestMapping(value=SIMPLE_STATION_ENDPOINT, method=RequestMethod.HEAD, produces={MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
-	@Async
-	public void simpleStationHeadRequest(HttpServletRequest request, HttpServletResponse response) {
+	public DeferredResult<Boolean> simpleStationHeadRequest(HttpServletRequest request, HttpServletResponse response) {
 		log.info("Processing Head: {}", request.getQueryString());
 		BigDecimal logId = logService.logRequest(request, response);
 		SCManager session = null;
+		
+		DeferredResult<Boolean> deferral = new DeferredResult<Boolean>();
 		try {
-			session = doHeader(request, response, logId);
+			session = doHeader(request, response, logId, deferral);
 		} finally {
 			logService.logRequestComplete(logId, String.valueOf(response.getStatus()));
-			if (session != null) {
-				session.close();
-			}
+			Closer.close(session);
 			log.info("Processing Head complete: {}", request.getQueryString());
 		}
+		return deferral;
 	}
 	
 	/**
@@ -84,7 +86,7 @@ public class SimpleStationController implements HttpConstants, MybatisConstants,
 	 * @param response
 	 * @return cDAT session opened here for use on the GET request - bit kluggy but DRY'er code
 	 */
-	private SCManager doHeader(HttpServletRequest request, HttpServletResponse response, BigDecimal logId) {
+	private SCManager doHeader(HttpServletRequest request, HttpServletResponse response, BigDecimal logId,  DeferredResult<Boolean> deferral) {
 		response.setCharacterEncoding(DEFAULT_ENCODING);
 		pm = new ParameterValidation().preProcess(request, parameterHandler);
 		if ( ! pm.isValid() ) {
@@ -97,7 +99,9 @@ public class SimpleStationController implements HttpConstants, MybatisConstants,
 		HeaderWorker header = new HeaderWorker(response, ICountDao.STATION_NAMESPACE, pm, countDao, MimeType.xml);
 		String stationCount = session.addWorker("SimpleStationCount", header);
 		session.send(stationCount, Control.Start);
-		session.waitForComplete(stationCount, Time.SECOND.asMS());
+
+		StationController.waitForComplete(session, stationCount, deferral);
+
 		if (header.hasError()) {
 			//TODO We can't just eat these.
 			throw new RuntimeException(header.getCurrentError());
@@ -110,15 +114,15 @@ public class SimpleStationController implements HttpConstants, MybatisConstants,
 	 * station search request
 	 */
 	@RequestMapping(value=SIMPLE_STATION_ENDPOINT, method=RequestMethod.GET, produces={MIME_TYPE_XLSX, MIME_TYPE_XML, MIME_TYPE_JSON})
-	@Async
-	public void stationGetRequest(HttpServletRequest request, HttpServletResponse response) {
+	public DeferredResult<Boolean> stationGetRequest(HttpServletRequest request, HttpServletResponse response) {
 		log.trace(""); // blank line during trace
 		log.info("Processing Get: {}", request.getQueryString());
 		BigDecimal logId = logService.logRequest(request, response);
 		
 		SCManager session = null;
+		DeferredResult<Boolean> deferral = new DeferredResult<Boolean>();
 		try {
-			session = doHeader(request, response, logId);
+			session = doHeader(request, response, logId, deferral);
 			if (session != null) {
 				TransformOutputStream transformer;
 				String mimeTypeParam = pm.getParameter(Parameters.MIMETYPE);
@@ -140,10 +144,8 @@ public class SimpleStationController implements HttpConstants, MybatisConstants,
 				String stationName = session.addWorker("SimpleStation", worker);
 				session.send(stationName, Control.Start);
 				session.waitForComplete(stationName, Time.SECOND.asMS());
-				if (worker.hasError()) {
-					//TODO We can't just eat these.
-					throw new RuntimeException(worker.getCurrentError());
-				}
+
+				StationController.listenForComplete(session, stationName, deferral);
 			}
 		} catch (Exception e) {
 			//TODO We can't just eat these.
@@ -156,6 +158,7 @@ public class SimpleStationController implements HttpConstants, MybatisConstants,
 			}
 			log.info("Processing Get complete: {}", request.getQueryString());
 		}
+		return deferral;
 	}
 
 }


### PR DESCRIPTION
This is a means for have spring hold open the response stream until we set the result. Then, however, spring will throw an exception because we closed the stream after file complete. I tried to catch this but it is not an exception within our process but rather after our process is done. The logs are noisy with the thrown exception. We will need to look into this because it was initially discovered on OGCProxy. How many others have this issue?